### PR TITLE
Hardcode Schedule Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 .vercel
 .env
 !manifest.json
+bin
+lib
+include

--- a/api/campusdish_interface.py
+++ b/api/campusdish_interface.py
@@ -88,11 +88,12 @@ def get_schedule_data(restaurant: str) -> dict:
                 "end": 2300
             }
         }
-        if day_of_week >= 4: # if friday or later
+        if day_of_week >= 4: # if friday or later, there's no latenight
             schedule["dinner"]["end"] = 2000
-            if day_of_week >= 5: # if it's the weekend
+            if day_of_week >= 5: # if it's the weekend, lunch is brunch, and breakfast starts later
                 schedule["brunch"] = schedule["lunch"]
                 del schedule["lunch"]
+                schedule["breakfast"]["start"] = 900
         return schedule
 
 

--- a/api/campusdish_interface.py
+++ b/api/campusdish_interface.py
@@ -36,63 +36,64 @@ def get_schedule_data(restaurant: str) -> dict:
     schedule time use int because frontend work with int
     schedule time is (100*hours)+minutes, where hours is in 24-hour time
     '''
-    # hardcoded schedule (replace with actual schedule when bug is fixed)
-    day_of_week = get_irvine_time().tm_wday # 0-6 inclusive, 0=monday
-    schedule = {
-        "breakfast": {
-            "start": 715,
-            "end": 1100
-        },
-        "lunch": {
-            "start":1100,
-            "end":1630
-        },
-        "dinner": {
-            "start": 1630,
-            "end": 2300
-        }
-    }
-    if day_of_week >= 4: # if friday or later
-        schedule["dinner"]["end"] = 2000
-        if day_of_week >= 5: # if it's the weekend
-            schedule["brunch"] = schedule["lunch"]
-            del schedule["lunch"]
-    return schedule
-
-
-    url = 'https://uci.campusdish.com/LocationsAndMenus/'
-    if restaurant == 'Anteatery':
-        url += 'TheAnteatery'
-    else:
-        url += restaurant
-    schedule = {}
-    soup = bs(requests.get(url).text, 'html.parser')
-    meal_period = soup.select('.mealPeriod')[:5]
-    location_times = soup.select('span[class=location__times]')[:5]
-    for idx, meal in enumerate(meal_period):
-        meal = meal.getText().lower()
-        times = location_times[idx].getText().split(' - ')
-        if re.match(r"^\d?\d:\d\d(AM|PM)$", times[0]) and re.match(r"^\d?\d:\d\d(AM|PM)$", times[1]):
-            start = normalize_time_from_str(times[0])
-            end = normalize_time_from_str(times[1])
-            schedule[meal] = {"start": start, "end": end}
+    try:
+        raise NotImplementedError("This function has bugs and isn't ready for prod yet")
+        url = 'https://uci.campusdish.com/LocationsAndMenus/'
+        if restaurant == 'Anteatery':
+            url += 'TheAnteatery'
         else:
-            print("Invalid time")
-            schedule = {
-                "breakfast": {
-                    "start": 0,
-                    "end": 1
-                },
-                "lunch": {
-                    "start": 2,
-                    "end": 3
-                },
-                "dinner": {
-                    "start": 4,
-                    "end": 5
+            url += restaurant
+        schedule = {}
+        soup = bs(requests.get(url).text, 'html.parser')
+        meal_period = soup.select('.mealPeriod')[:5]
+        location_times = soup.select('span[class=location__times]')[:5]
+        for idx, meal in enumerate(meal_period):
+            meal = meal.getText().lower()
+            times = location_times[idx].getText().split(' - ')
+            if re.match(r"^\d?\d:\d\d(AM|PM)$", times[0]) and re.match(r"^\d?\d:\d\d(AM|PM)$", times[1]):
+                start = normalize_time_from_str(times[0])
+                end = normalize_time_from_str(times[1])
+                schedule[meal] = {"start": start, "end": end}
+            else:
+                print("Invalid time")
+                schedule = {
+                    "breakfast": {
+                        "start": 0,
+                        "end": 1
+                    },
+                    "lunch": {
+                        "start": 2,
+                        "end": 3
+                    },
+                    "dinner": {
+                        "start": 4,
+                        "end": 5
+                    }
                 }
+        return schedule
+    except:
+        # return hardcoded schedule
+        day_of_week = get_irvine_time().tm_wday # 0-6 inclusive, 0=monday
+        schedule = {
+            "breakfast": {
+                "start": 715,
+                "end": 1100
+            },
+            "lunch": {
+                "start":1100,
+                "end":1630
+            },
+            "dinner": {
+                "start": 1630,
+                "end": 2300
             }
-    return schedule
+        }
+        if day_of_week >= 4: # if friday or later
+            schedule["dinner"]["end"] = 2000
+            if day_of_week >= 5: # if it's the weekend
+                schedule["brunch"] = schedule["lunch"]
+                del schedule["lunch"]
+        return schedule
 
 
 def get_themed_event_data(restaurant: str) -> list[dict]:

--- a/api/campusdish_interface.py
+++ b/api/campusdish_interface.py
@@ -36,6 +36,30 @@ def get_schedule_data(restaurant: str) -> dict:
     schedule time use int because frontend work with int
     schedule time is (100*hours)+minutes, where hours is in 24-hour time
     '''
+    # hardcoded schedule (replace with actual schedule when bug is fixed)
+    day_of_week = get_irvine_time().tm_wday # 0-6 inclusive, 0=monday
+    schedule = {
+        "breakfast": {
+            "start": 715,
+            "end": 1100
+        },
+        "lunch": {
+            "start":1100,
+            "end":1630
+        },
+        "dinner": {
+            "start": 1630,
+            "end": 2300
+        }
+    }
+    if day_of_week >= 4: # if friday or later
+        schedule["dinner"]["end"] = 2000
+        if day_of_week >= 5: # if it's the weekend
+            schedule["brunch"] = schedule["lunch"]
+            del schedule["lunch"]
+    return schedule
+
+
     url = 'https://uci.campusdish.com/LocationsAndMenus/'
     if restaurant == 'Anteatery':
         url += 'TheAnteatery'

--- a/api/index.py
+++ b/api/index.py
@@ -79,23 +79,7 @@ class handler(BaseHTTPRequestHandler):
                     db_ref.set(data)
 
                 else:
-                    data = db_data
-                mock_schedule = {
-                    "breakfast": {
-                        "start": 0,
-                        "end": 1
-                    },
-                    "lunch": {
-                        "start":2,
-                        "end":3
-                    },
-                    "dinner": {
-                        "start": 4,
-                        "end": 5
-                    }
-                }
-                if "schedule" not in data:
-                    data["schedule"] = mock_schedule
+                    data = db_data 
                 if "themed" not in data:
                     data["themed"] = []
             else:

--- a/api/index.py
+++ b/api/index.py
@@ -80,6 +80,25 @@ class handler(BaseHTTPRequestHandler):
 
                 else:
                     data = db_data 
+
+                mock_schedule = {
+                    "breakfast": {
+                        "start": 1,
+                        "end": 2
+                    },
+                    "lunch": {
+                        "start":2,
+                        "end":3
+                    },
+                    "dinner": {
+                        "start": 3,
+                        "end": 4
+                    }
+                }
+                
+                if "schedule" not in data:
+                    data["schedule"] = mock_schedule
+                
                 if "themed" not in data:
                     data["themed"] = []
             else:


### PR DESCRIPTION
Right now the schedule is broken because it displays the wrong time for dinner and includes both brunch and lunch. My fix is just returning a hard-coded version of the schedule that depends on the day of the week.

It's wrapped behind a try/catch block because I'm thinking we can just leave the hard-coded schedule in the function as a backup if the normal schedule fetcher fails.

I changed the mock schedule returned by index a little bit so the times had the start and ends coincide like they do normally.

We should still fix the actual schedule bug but I wanted to get a temporary fix out to production as soon as possible.
