### PR TITLE
Fix CORS Issue

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -138,6 +138,7 @@ class handler(BaseHTTPRequestHandler):
         self.send_response(status_code)
         if type(body) == str:
             self.send_header("Content-type", "text/plain")
+            self.send_header("Access-Control-Allow-Origin", "*") # this lets the browser know it's okay to make a cross origin request from any origin.
             self.end_headers()
             self.wfile.write(body.encode())
         else:


### PR DESCRIPTION
The problem this fixes:
When using the browser `fetch` API to make an HTTP request, the browser will only return the response it gets if the server sends back an access-control-allow-origin response header that matches the origin of the fetch request. The browser automatically grabs the current URL to send as the origin in the request headers. By putting a wildcard `*` in the response header, this lets the browser know that it should let any origin access the data it got from the API.